### PR TITLE
feat: レスポンシブデザインの改善

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -24,26 +24,45 @@ interface GridProps<T> {
 // デフォルトのグリッド設定
 const DEFAULT_COLUMNS = {
   default: "repeat(auto-fill, minmax(320px, 1fr))",
-  mobile: "1fr",
+  tablet: "repeat(auto-fill, minmax(280px, 1fr))",
+  mobile: "repeat(auto-fill, minmax(240px, 1fr))",
+  small: "1fr",
 };
 
 const DEFAULT_GAP = {
-  default: "1rem",
-  mobile: "0.5rem",
+  default: "1.5rem",
+  tablet: "1rem",
+  mobile: "0.75rem",
+  small: "0.5rem",
 };
 
 // スタイル付きグリッドコンテナ
 const StyledGrid = styled.div<{
-  $columns: { default?: string; mobile?: string };
-  $gap: { default?: string; mobile?: string };
+  $columns: {
+    default?: string;
+    tablet?: string;
+    mobile?: string;
+    small?: string;
+  };
+  $gap: { default?: string; tablet?: string; mobile?: string; small?: string };
 }>`
   display: grid;
   grid-template-columns: ${({ $columns }) => $columns.default || DEFAULT_COLUMNS.default};
   gap: ${({ $gap }) => $gap.default || DEFAULT_GAP.default};
   
+  @media (max-width: ${theme.breakpoints.tablet}) {
+    grid-template-columns: ${({ $columns }) => $columns.tablet || DEFAULT_COLUMNS.tablet};
+    gap: ${({ $gap }) => $gap.tablet || DEFAULT_GAP.tablet};
+  }
+  
   @media (max-width: ${theme.breakpoints.mobile}) {
     grid-template-columns: ${({ $columns }) => $columns.mobile || DEFAULT_COLUMNS.mobile};
     gap: ${({ $gap }) => $gap.mobile || DEFAULT_GAP.mobile};
+  }
+  
+  @media (max-width: ${theme.breakpoints.small}) {
+    grid-template-columns: ${({ $columns }) => $columns.small || DEFAULT_COLUMNS.small};
+    gap: ${({ $gap }) => $gap.small || DEFAULT_GAP.small};
   }
 `;
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,18 +25,41 @@ const Nav = styled.nav`
   
   @media (max-width: ${theme.breakpoints.mobile}) {
     padding: 0 ${theme.space.sm};
+    flex-wrap: wrap;
+    gap: ${theme.space.xs};
   }
 `;
 
 const Logo = styled(Link)`
   display: inline-block;
   height: ${theme.sizes.button.md};
+  flex-shrink: 0;
+  
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    height: ${theme.sizes.button.sm};
+  }
 `;
 
 const MenuList = styled.ul<{ $isOpen: boolean }>`
   display: flex;
   flex-direction: row;
   gap: ${theme.space.lg};
+  align-items: center;
+  flex-wrap: wrap;
+  
+  @media (max-width: ${theme.breakpoints.tablet}) {
+    gap: ${theme.space.md};
+  }
+  
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    gap: ${theme.space.sm};
+    font-size: ${theme.typography.fontSize.sm};
+  }
+  
+  @media (max-width: ${theme.breakpoints.small}) {
+    gap: ${theme.space.xs};
+    font-size: ${theme.typography.fontSize.xs};
+  }
 `;
 
 const MenuItem = styled.li`
@@ -47,6 +70,7 @@ const MenuItem = styled.li`
     text-decoration: none;
     text-transform: uppercase;
     letter-spacing: ${theme.typography.heading.letterSpacingEn};
+    white-space: nowrap;
     
     &:hover {
       color: ${theme.colors.primary.light};

--- a/src/components/TabComponents.tsx
+++ b/src/components/TabComponents.tsx
@@ -9,6 +9,13 @@ export const TabContainer = styled.div`
   gap: 2rem;
   margin-bottom: 2rem;
   position: relative;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  
+  &::-webkit-scrollbar {
+    display: none;
+  }
   
   /* 右端まで伸びる罫線 */
   &::after {
@@ -19,11 +26,20 @@ export const TabContainer = styled.div`
     margin-left: 2rem;
   }
   
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    flex-wrap: wrap;
+  @media (max-width: ${theme.breakpoints.tablet}) {
+    gap: 1.5rem;
     
     &::after {
       display: none;
     }
+  }
+  
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    gap: 1rem;
+    padding-bottom: 0.5rem;
+  }
+  
+  @media (max-width: ${theme.breakpoints.small}) {
+    gap: 0.75rem;
   }
 `;

--- a/src/pages/VoicebankPage/sections/LitCharacterSection.tsx
+++ b/src/pages/VoicebankPage/sections/LitCharacterSection.tsx
@@ -64,6 +64,10 @@ const StyledContentContainer = styled(ContentContainer)`
 const ProfileWrapper = styled(GridContainer)`
   margin-top: 1rem;
   width: 100%;
+  
+  @media (max-width: ${theme.breakpoints.small}) {
+    margin-top: 0.5rem;
+  }
 `;
 
 // デモソングセクション

--- a/src/pages/VoicebankPage/sections/LitMainSection.tsx
+++ b/src/pages/VoicebankPage/sections/LitMainSection.tsx
@@ -113,7 +113,9 @@ const CharacterImage = styled.div`
   position: absolute;
   bottom: 0;
   right: 0;
-  max-height: 10vh;
+  width: auto;
+  height: 90vh;
+  max-height: 90vh;
   display: flex;
   align-items: flex-end;
   justify-content: flex-end;
@@ -121,8 +123,41 @@ const CharacterImage = styled.div`
   pointer-events: none;
   
   img {
-    object-fit: unset;
+    width: auto;
+    height: 100%;
+    max-height: 90vh;
+    object-fit: contain;
+    object-position: bottom right;
     filter: drop-shadow(${theme.shadows.glow.small});
+  }
+  
+  @media (max-width: ${theme.breakpoints.desktop}) {
+    height: 85vh;
+    max-height: 85vh;
+    
+    img {
+      max-height: 85vh;
+    }
+  }
+  
+  @media (max-width: ${theme.breakpoints.tablet}) {
+    height: 70vh;
+    max-height: 70vh;
+    right: -5%;
+    
+    img {
+      max-height: 70vh;
+    }
+  }
+  
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    height: 60vh;
+    max-height: 60vh;
+    right: -10%;
+    
+    img {
+      max-height: 60vh;
+    }
   }
 `;
 


### PR DESCRIPTION
## Summary
- Header、タブ、グリッドコンポーネントのレスポンシブ対応を改善
- Voicebank ページの立ち絵がビューポートに収まるよう調整

## 変更内容

### ヘッダーナビゲーション
- モバイル表示時の折り返しとロゴサイズの調整
- ブレークポイント別のフォントサイズと余白調整

### タブコンポーネント  
- 横スクロール対応で狭い画面でもタブが改行されない
- ブレークポイント別の余白調整

### グリッドレイアウト
- より細かいブレークポイント設定（tablet/mobile/small）
- 画面幅に応じた最適なカラム数とギャップ

### Voicebank 立ち絵
- ビューポートの高さに収まるよう最大90vhに制限
- ブレークポイント別の高さ調整と位置調整

## Test plan
- [x] モバイル（375px）でヘッダーナビゲーションが適切に表示される
- [x] タブレット（768px）でタブが1行に収まる
- [x] Voicebank ページの立ち絵が画面内に収まる
- [x] 各ブレークポイントでグリッドレイアウトが適切に調整される

🤖 Generated with [Claude Code](https://claude.ai/code)